### PR TITLE
Format Time and Date objects using `to_fs(format)` instead of `to_s(format)` (#194)

### DIFF
--- a/lib/active_ldap/base.rb
+++ b/lib/active_ldap/base.rb
@@ -1036,7 +1036,13 @@ module ActiveLdap
         if value.is_a?(String) and value.length > 50
           "#{value[0, 50]}...".inspect
         elsif value.is_a?(Date) || value.is_a?(Time)
-          "#{value.to_s(:db)}"
+          if value.respond_to?(:to_fs)
+            # Support for Rails >= 7.0
+            value.to_fs(:db)
+          else
+            # Support for Rails < 7.0
+            value.to_s(:db)
+          end
         else
           value.inspect
         end


### PR DESCRIPTION
Starting from [Rails 7.0](https://guides.rubyonrails.org/7_0_release_notes.html#active-support), the custom version of to_s where you could specify a format, `#to_s(format)`, is deprecated and `#to_fs(format)` should be used instead. In [Rails 7.1](https://guides.rubyonrails.org/7_1_release_notes.html#active-support), `#to_s(format)` was completely removed.
See [here](https://github.com/rails/rails/pull/43772/commits/58ecdd0cf2ee81e06894d73d73535a8f521cec45) for the reasoning behind this change.

Because of this change, inspecting an LDAP::Entry instance which has a date or time as attribute would throw an error when using Rails 7.1.

With these changes, `to_fs(:db)` is used when it exists (when using Rails 7+), otherwise it falls back to `to_s(:db)`. I also removed the string interpolation, as both methods already return a String.